### PR TITLE
test out some other plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-jcheckstyle" % "0.1.4")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+
+addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
 
 resolvers += Resolver.sonatypeRepo("public")


### PR DESCRIPTION
```
[info] Loading project definition from /Users/rchen/open-source/sbt-test/project
[info] Updating {file:/Users/rchen/open-source/sbt-test/project/}sbt-test-build...
[info] Resolving org.scala-sbt.ivy#ivy;2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.eed3si9n/sbt-buildinfo/scala_2.10/sbt_0.13/0.5.0/jars/sbt-buildinfo.jar ...
[info] 	[SUCCESSFUL ] com.eed3si9n#sbt-buildinfo;0.5.0!sbt-buildinfo.jar (1064ms)
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.cavorite/sbt-avro/scala_2.10/sbt_0.13/0.3.2/jars/sbt-avro.jar ...
[info] 	[SUCCESSFUL ] com.cavorite#sbt-avro;0.3.2!sbt-avro.jar (824ms)
[info] downloading https://repo1.maven.org/maven2/org/apache/avro/avro/1.7.5/avro-1.7.5.jar ...
[info] 	[SUCCESSFUL ] org.apache.avro#avro;1.7.5!avro.jar (164ms)
[info] downloading https://repo1.maven.org/maven2/org/apache/avro/avro-compiler/1.7.5/avro-compiler-1.7.5.jar ...
[info] 	[SUCCESSFUL ] org.apache.avro#avro-compiler;1.7.5!avro-compiler.jar (74ms)
[info] downloading https://repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.3/paranamer-2.3.jar ...
[info] 	[SUCCESSFUL ] com.thoughtworks.paranamer#paranamer;2.3!paranamer.jar (72ms)
[info] downloading https://repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.0.5/snappy-java-1.0.5.jar ...
[info] 	[SUCCESSFUL ] org.xerial.snappy#snappy-java;1.0.5!snappy-java.jar(bundle) (186ms)
[info] downloading https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.4.1/commons-compress-1.4.1.jar ...
[info] 	[SUCCESSFUL ] org.apache.commons#commons-compress;1.4.1!commons-compress.jar (131ms)
[info] downloading https://repo1.maven.org/maven2/org/tukaani/xz/1.0/xz-1.0.jar ...
[info] 	[SUCCESSFUL ] org.tukaani#xz;1.0!xz.jar (107ms)
[info] downloading https://repo1.maven.org/maven2/org/apache/velocity/velocity/1.7/velocity-1.7.jar ...
[info] 	[SUCCESSFUL ] org.apache.velocity#velocity;1.7!velocity.jar (96ms)
[info] Done updating.
[info] Set current project to sbt-test (in build file:/Users/rchen/open-source/sbt-test/)
```

Works well for the other two plugins sbt-buildinfo and sbt-avro 